### PR TITLE
Fix role names and clean login

### DIFF
--- a/app/Actions/Fortify/LoginResponse.php
+++ b/app/Actions/Fortify/LoginResponse.php
@@ -18,8 +18,8 @@ class LoginResponse implements LoginResponseContract
             $user->hasRole('supervisor') => '/supervisor/dashboard',
             $user->hasRole('employee') => '/employee/dashboard',
             $user->hasRole('reception') => '/reception/dashboard',
-            $user->hasRole('agents') => '/agents/dashboard',
-            $user->hasRole('clients') => '/clients/dashboard',
+            $user->hasRole('agent') => '/agent/dashboard',
+            $user->hasRole('client') => '/client/dashboard',
             $user->hasRole('guest') => '/guest/dashboard',
             default => '/',
         };

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -27,32 +27,7 @@ class AuthenticatedSessionController extends Controller
         $request->authenticate();
         $request->session()->regenerate();
 
-        $user = Auth::user();
-
-        // Redirect based on user role
-        if ($user->hasRole('super admin')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('hr manager')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('hr staff')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('manager')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('supervisor')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('employee')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('reception')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('agent')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('clients')) {
-            return redirect()->route('dashboard');
-        } elseif ($user->hasRole('guest')) {
-            return redirect()->route('dashboard');
-        }
-
-        // Fallback if no valid role is found
+        // All roles currently use the same dashboard route
         return redirect()->route('dashboard');
     }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -18,10 +18,10 @@ class DashboardController extends Controller
             'employee'    => 'dashboard.employee',
             'reception'   => 'dashboard.reception',
             'guest'       => 'dashboard.guest',
-            'agent'       => 'dashboard.agent',
+            'agent'       => 'dashboard.agents',
             'supervisor'  => 'dashboard.supervisor',
             'management'  => 'dashboard.management',
-            'clients'     => 'dashboard.clients',
+            'client'      => 'dashboard.clients',
         ];
 
         foreach ($dashboards as $role => $view) {

--- a/app/Http/Controllers/UserManagementController.php
+++ b/app/Http/Controllers/UserManagementController.php
@@ -38,7 +38,7 @@ class UserManagementController extends Controller
     public function listAgentsAndClients()
     {
         $agents = User::role('agent')->get();
-        $clients = User::role('clients')->get(); // assuming role is called 'clients'
+        $clients = User::role('client')->get();
 
         return view('settings.viewagentsandclients', compact('agents', 'clients'));
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,8 +23,8 @@ class DatabaseSeeder extends Seeder
             'supervisor',
             'employee',
             'reception',
-            'agents',
-            'clients',
+            'agent',
+            'client',
             'guest'
         ];
 

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -35,8 +35,8 @@ class RolesAndPermissionsSeeder extends Seeder
             'employee' => [],
             'management' => ['view employees'],
             'reception' => ['view employees'],
-            'agents' => [],
-            'clients' => [],
+            'agent' => [],
+            'client' => [],
             'guest' => [],
         ];
 

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -18,8 +18,8 @@ class RolesSeeder extends Seeder
             'supervisor',
             'employee',
             'reception',
-            'agents',
-            'clients',
+            'agent',
+            'client',
             'guest'
         ];
 


### PR DESCRIPTION
## Summary
- clean up login redirect logic
- use singular `agent` and `client` roles consistently
- update dashboard mapping for new roles
- update seeders for role name changes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859da5ed690832ba19ffff268bf3f1c