### PR TITLE
Add role-based sidebar config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ We would like to extend our thanks to the following sponsors for funding Laravel
 - **[byte5](https://byte5.de)**
 - **[OP.GG](https://op.gg)**
 
+## Sidebar Access Control
+
+The sidebar items are configured in `config/sidebar.php`. Each entry defines
+the required roles or permissions needed to view a module. Users lacking the
+specified roles or permissions will not see the menu item in the sidebar.
+
 ## Contributing
 
 Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/config/sidebar.php
+++ b/config/sidebar.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    [
+        'label' => 'Employees',
+        'icon' => 'mdi:account-group-outline',
+        'route' => 'employees.index',
+        'permission' => 'view employees',
+    ],
+    [
+        'label' => 'Recruitment',
+        'icon' => 'mdi:briefcase-account-outline',
+        'route' => 'vacancies.index',
+        'roles' => ['super admin', 'hr manager', 'hr staff'],
+    ],
+    [
+        'label' => 'Email',
+        'icon' => 'mage:email',
+        'permission' => 'access email',
+        'route' => '#',
+    ],
+    [
+        'label' => 'Chat',
+        'icon' => 'bi:chat-dots',
+        'permission' => 'access chat',
+        'route' => '#',
+    ],
+    [
+        'label' => 'Calendar',
+        'icon' => 'solar:calendar-outline',
+        'permission' => 'access calendar',
+        'route' => '#',
+    ],
+];

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -27,54 +27,27 @@
 
             <li class="sidebar-menu-group-title">Application</li>
 
-            @can('view employees')
-            <li>
-                <a href="{{ route('employees.index') }}">
-                    <iconify-icon icon="mdi:account-group-outline" class="menu-icon"></iconify-icon>
-                    <span>Employees</span>
-                </a>
-            </li>
-            @endcan
+            @php($modules = config('sidebar'))
+            @foreach($modules as $module)
+                @php
+                    $show = true;
+                    if(isset($module['permission'])) {
+                        $show = $show && auth()->user()->can($module['permission']);
+                    }
+                    if(isset($module['roles'])) {
+                        $show = $show && auth()->user()->hasAnyRole($module['roles']);
+                    }
+                @endphp
+                @if($show)
+                    <li>
+                        <a href="{{ $module['route'] !== '#' ? route($module['route']) : '#' }}">
+                            <iconify-icon icon="{{ $module['icon'] }}" class="menu-icon"></iconify-icon>
+                            <span>{{ $module['label'] }}</span>
+                        </a>
+                    </li>
+                @endif
+            @endforeach
 
-            {{-- Example: Only show HR Manager module to users with that permission --}}
-            @can('view hr dashboard')
-            <li>
-                <a href="{{ route('hr.dashboard') }}">
-                    <iconify-icon icon="mdi:briefcase-account-outline" class="menu-icon"></iconify-icon>
-                    <span>HR Dashboard</span>
-                </a>
-            </li>
-            @endcan
-
-            {{-- Additional modules with permission checks --}}
-            @can('access email')
-            <li>
-                <a href="#">
-                    <iconify-icon icon="mage:email" class="menu-icon"></iconify-icon>
-                    <span>Email</span>
-                </a>
-            </li>
-            @endcan
-
-            @can('access chat')
-            <li>
-                <a href="#">
-                    <iconify-icon icon="bi:chat-dots" class="menu-icon"></iconify-icon>
-                    <span>Chat</span>
-                </a>
-            </li>
-            @endcan
-
-            @can('access calendar')
-            <li>
-                <a href="#">
-                    <iconify-icon icon="solar:calendar-outline" class="menu-icon"></iconify-icon>
-                    <span>Calendar</span>
-                </a>
-            </li>
-            @endcan
-
-            {{-- Add more module entries below using @can(...) --}}
         </ul>
     </div>
 </aside>


### PR DESCRIPTION
## Summary
- configure sidebar modules and allowed roles in a new `config/sidebar.php`
- render sidebar items dynamically based on user roles and permissions
- document sidebar access configuration in README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a007dfd40832b9f938bcd5d534ccb