### PR TITLE
Fix parse error in sidebar

### DIFF
--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -27,7 +27,9 @@
 
             <li class="sidebar-menu-group-title">Application</li>
 
-            @php($modules = config('sidebar'))
+            @php
+                $modules = config('sidebar');
+            @endphp
             @foreach($modules as $module)
                 @php
                     $show = true;


### PR DESCRIPTION
## Summary
- fix parse error in sidebar

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642776dc1c832bb9fd8b12ae34745d